### PR TITLE
Illustrate no-changing placeholders at fragments after first time on the next time with another value

### DIFF
--- a/examples/star-wars/src/components/StarWarsApp.js
+++ b/examples/star-wars/src/components/StarWarsApp.js
@@ -35,12 +35,17 @@ class StarWarsApp extends React.Component {
 }
 
 export default Relay.createContainer(StarWarsApp, {
+  initialVariables: { shipCount: 10 },
+  prepareVariables: function(prevVars) {
+    console.log('prepareVariables:', prevVars);
+    return prevVars;
+  },
   fragments: {
     factions: () => Relay.QL`
       fragment on Faction @relay(plural: true) {
         id,
         name,
-        ships(first: 10) {
+        ships(first: $shipCount) {
           edges {
             node {
               id,

--- a/examples/star-wars/src/renderOnServer.js
+++ b/examples/star-wars/src/renderOnServer.js
@@ -4,7 +4,10 @@ import path from 'path';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import Relay from 'react-relay';
-import rootContainerProps from './rootContainerProps';
+import util from 'util';
+//import rootContainerProps from './rootContainerProps';
+import StarWarsApp from './components/StarWarsApp';
+import StarWarsAppHomeRoute from './routes/StarWarsAppHomeRoute';
 
 const GRAPHQL_URL = `http://localhost:8080/graphql`;
 
@@ -12,8 +15,18 @@ Relay.injectNetworkLayer(new Relay.DefaultNetworkLayer(GRAPHQL_URL));
 
 GraphQLStoreChangeEmitter.injectBatchingStrategy(() => {});
 
-export default (res, next) => {
+export default (req, res, next) => {
+    let { names, ships } = req.query;
+    let rootContainerProps = {
+        Component: StarWarsApp,
+        route: new StarWarsAppHomeRoute({
+            factionNames: (names || 'empire,rebels').split(','),
+            shipCount: ships | 0
+        }),
+    };
+
     IsomorphicRelay.prepareData(rootContainerProps).then(data => {
+        console.log('DATA:',util.inspect(data,false,10,true));
         const reactOutput = ReactDOMServer.renderToString(
             <IsomorphicRelay.RootContainer {...rootContainerProps} />
         );

--- a/examples/star-wars/src/server.js
+++ b/examples/star-wars/src/server.js
@@ -18,7 +18,7 @@ app.get('/app.js', (req, res) => {
 
 // Serve HTML
 app.get('/', (req, res, next) => {
-    renderOnServer(res, next);
+    renderOnServer(req, res, next);
 });
 
 app.listen(APP_PORT, () => {


### PR DESCRIPTION
I have a problem - no-changing placeholders for route variables at Relay.QL container child fragments, after first time on the next time with another value. 
### My story of this problem:

At some our project, i need to get data with additional criterias, used at Relay's Containers fragments (at this pool request - see StarWarsApp component). To make it, I've been instantiated a route, with additional variable  (shipCount at this PR, see file: examples/star-wars/src/renderOnServer.js, lines 22-25). I also maked some changes, to take this variables values (factionNames, shipCount) from HTTP GET params for illustrate a problem.
##### Demo of this problem:

Start this application. 
Go to the following url: [http://localhost:8080/?names=empire,rebels&ships=1](http://localhost:8080/?names=empire,rebels&ships=1) You see:

```
1. Galactic Empire
    1. TIE Fighter

2. Alliance to Restore the Republic
    1. X-Wing
```

as expected. But, when you go to another url: [http://localhost:8080/?names=empire,rebels&ships=2](http://localhost:8080/?names=empire,rebels&ships=2) (with ships=2, or ships=3 or any value), you always get the same result as i write above. I.e., the count of ships data, that returns after: 

``` javascript
IsomorphicRelay.prepareData(rootContainerProps).then(data => { // ships data count not changed
});
```

are not changed. (To see this, i insert `console.log` at line 29 of file: examples/star-wars/src/renderOnServer.js of this PR)
When you stop server.js and restart it again, you can go to another url, as you previous want, for example with ships=2: [http://localhost:8080/?names=empire,rebels&ships=2](http://localhost:8080/?names=empire,rebels&ships=2), then you see result as expected: 

```
1. Galactic Empire
    1. TIE Fighter
    2. TIE Interceptor

2. Alliance to Restore the Republic
    1. X-Wing
    2. Y-Wing
```

But another values of ships - 3 or 4 not change the count of returning ships on next queries - it always be equal 2. 
What can we do with this problem?

P.S. Previously, on my another project, i've been investigated this problem. The reason - is the caching mechanism at https://github.com/facebook/relay/blob/master/src/query/buildRQL.js at `buildRQL.Query` on lines 95-102: 

``` javascript
Query(
    queryBuilder: RelayQLQueryBuilder,
    Component: any,
    queryName: string,
    values: Variables
  ): ?ConcreteQuery {
    let componentCache = queryCache.get(queryBuilder);
    let node;
    if (!componentCache) {
      componentCache = new Map();
      queryCache.set(queryBuilder, componentCache);
    } else {
      node = componentCache.get(Component);
    }
    if (!node) {
```

This method calling by `Relay.getQueries`, that you use at `IsomorphicRelay.prepareData`. The main problem of this method `Query` at buildRQL.js, that it call lines 113-147:

``` javascript
node = queryBuilder(Component, variables);
const query = QueryBuilder.getQuery(node);
if (query) {
  ... // set variables on theirs placeholders at child fragments
}
componentCache.set(Component, node);
```

only ones. `queryBuilder` - it's our transpiled Relay.QL query of RelayQueryConfig. When above lines  calls, at this this time variables are set on theirs placeholders at child fragments of this query. 
On next other times, the `node` will be taken from the cache, with **previous values** of placeholders - we can see it on Demo. I also **want to note**, that not changing **only** value at placeholder at child fragment at concrete result `node` (node will be used to run query to fetch data)! The values of variables of Relay.Route - StarWarsAppHomeRoute (factionNames, shipCount) - are changing properly! We can see it by `console.log` at line 40 of file: examples/star-wars/src/components/StarWarsApp.js of this PR. 
As you can see, at this example PR - problem placeholder at child fragment only one - `$shipCount`

P.P.S I create this example PR, that you can more simple see the code-difference and also what i mean.
Thank you.
