### PR TITLE
Fixes for <IE11

### DIFF
--- a/examples/star-wars/webpack.config.js
+++ b/examples/star-wars/webpack.config.js
@@ -1,7 +1,10 @@
 var path = require('path');
 
 module.exports = {
-    entry: path.resolve(__dirname, 'lib', 'client.js'),
+    entry: [
+      'babel-core/polyfill',
+      path.resolve(__dirname, 'lib', 'client.js'),
+    ],
     output: {
         filename: 'app.js',
         path: path.resolve(__dirname, 'lib'),

--- a/src/IsomorphicRenderer.js
+++ b/src/IsomorphicRenderer.js
@@ -8,7 +8,7 @@ import checkRelayQueryData from 'react-relay/lib/checkRelayQueryData';
 import flattenSplitRelayQueries from 'react-relay/lib/flattenSplitRelayQueries';
 import splitDeferredRelayQueries from 'react-relay/lib/splitDeferredRelayQueries';
 
-export default class IsomorphicRenderer extends RelayRenderer {
+class IsomorphicRenderer extends RelayRenderer {
     _runQueries(props) {
         // _runQueries should not be called on server side,
         // so don't call it from constructor, and call it from componentDidMount instead
@@ -65,7 +65,13 @@ export default class IsomorphicRenderer extends RelayRenderer {
             this._runQueries(this.props);
         }
     }
+
 }
+
+IsomorphicRenderer.propTypes = RelayRenderer.propTypes;
+IsomorphicRenderer.childContextTypes = RelayRenderer.childContextTypes;
+
+export default IsomorphicRenderer;
 
 const queuedStore = RelayStoreData.getDefaultInstance().getQueuedStore();
 


### PR DESCRIPTION
These changes allow the example and library to work on IE9.

Previously the IsomorphicRenderer was not picking up the propTypes and childContextTypes from the RelayRenderer base class, causing an error in getChildContext.

I also added the babel polyfill to the example so it would run.
