### PR TITLE
Local network layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ const GRAPHQL_URL = `http://localhost:8080/graphql`;
 Relay.injectNetworkLayer(new Relay.DefaultNetworkLayer(GRAPHQL_URL));
 ```
 
+If you want to execute graphql queries on the same server that is doing the rendering and avoid
+making HTTP requests to yourself, you can use `IsomorphicRelay.LocalNetworkLayer` like this:
+```javascript
+import IsomorphicRelay from 'isomorphic-relay';
+import schema from 'your-graphql-schema';
+import rootValue from 'your-graphql-root-value';
+
+Relay.injectNetworkLayer(new IsomorphicRelay.LocalNetworkLayer(schema, rootValue));
+```
+
 When processing a request **on the server**, prepare the data using `IsomorphicRelay.prepareData`,
 then render React markup using `IsomorphicRelay.RootContainer` in place of `Relay.RootContainer`
 (pass `props` returned by  `IsomorphicRelay.prepareData`), and send the React output along with the

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-static-container": "^1.0.0-alpha.1"
   },
   "peerDependencies": {
+    "graphql": "*",
     "react-relay": "0.7.1 - 0.7.3"
   },
   "devDependencies": {

--- a/src/IsomorphicRelay.js
+++ b/src/IsomorphicRelay.js
@@ -1,8 +1,10 @@
+import LocalNetworkLayer from './LocalNetworkLayer';
 import injectPreparedData from './injectPreparedData';
 import IsomorphicRootContainer from './IsomorphicRootContainer';
 import prepareData from './prepareData';
 
 export default {
+    LocalNetworkLayer,
     injectPreparedData,
     prepareData,
     RootContainer: IsomorphicRootContainer,

--- a/src/LocalNetworkLayer.js
+++ b/src/LocalNetworkLayer.js
@@ -1,0 +1,40 @@
+import { graphql } from 'graphql';
+
+export default class LocalNetworkLayer {
+  constructor(schema, rootValue) {
+    this._schema = schema;
+    this._rootValue = rootValue;
+  }
+
+  _sendRequest(request) {
+    graphql(this._schema, request.getQueryString(), this._rootValue, request.getVariables()).then(result => {
+      if(result.errors) {
+        const error = new Error(`Executing query "${request.getDebugName()}" has failed for the following reasons: ${result.errors}`);
+        error.errors = result.errors;
+        request.reject(error);
+      } else {
+        request.resolve({ response: result.data });
+      }
+    });
+  }
+
+  sendMutation(request) {
+    const files = request.getFiles();
+    if(files && Object.keys(files).length !== 0) {
+      request.reject(new Error(`It makes no sense to send files through LocalNetworkLayer. Please make sure you are not trying to do so with "${request.getDebugName()}" mutation on the server.`));
+    } else {
+      this._sendRequest(request);
+    }
+  }
+
+  sendQueries(requests) {
+    for(const request of requests) {
+      this._sendRequest(request);
+    }
+  }
+
+  supports(...options) {
+    // currently the only defined option is "defer" and we don't support it
+    return false;
+  }
+}


### PR DESCRIPTION
Currently when rendering on the server, you are suggesting to just use standard `Relay.DefaultNetworkLayer`, which will always make HTTP requests. I think it's a pretty common use case to render on the same server where GraphQL is, thus eliminating the need to send those requests.

This PR adds a small utility class `LocalNetworkLayer` to do just that. All you need to do is to give it a reference to GraphQL schema and root value in the constructor, and it will execute all queries locally. It cannot handle file uploads, but if you are trying to upload files locally from your server to your server, you are doing something seriously wrong.

I have also added a `graphql` peer dependency, because it is required to execute those queries locally.

Of course, this will only be really useful when relay merges your PR to contextualize network layer. Then you should be able to pass a new instance with a different root value for each rendering.
