### PR TITLE
Updated dependencies (Relay 0.8.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,19 +30,21 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "babel-runtime": "^6.3.19",
-    "fbjs": "^0.7.0",
-    "react-static-container": "^1.0.0-alpha.1"
+    "babel-runtime": "^6.6.1",
+    "fbjs": "^0.8.0",
+    "react-static-container": "^1.0.1"
   },
   "peerDependencies": {
-    "react-relay": "0.7.1 - 0.7.3"
+    "react": "^15.0.1 || ^0.14.2",
+    "react-dom": "^15.0.1 || ^0.14.2",
+    "react-relay": "0.7.1 - 0.8.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.3.17",
-    "babel-plugin-transform-es2015-classes": "^6.3.13",
-    "babel-plugin-transform-runtime": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13"
+    "babel-cli": "^6.7.5",
+    "babel-plugin-transform-es2015-classes": "^6.6.5",
+    "babel-plugin-transform-runtime": "^6.7.5",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "react": "^15.0.1 || ^0.14.2",
     "react-dom": "^15.0.1 || ^0.14.2",
-    "react-relay": "0.7.1 - 0.8.0"
+    "react-relay": "^0.8.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/src/IsomorphicRootContainer.js
+++ b/src/IsomorphicRootContainer.js
@@ -6,7 +6,7 @@ function IsomorphicRootContainer({
     Component,
     forceFetch,
     onReadyStateChange,
-    relayContext,
+    relayEnvironment,
     renderFailure,
     renderFetched,
     renderLoading,
@@ -18,7 +18,7 @@ function IsomorphicRootContainer({
             forceFetch={forceFetch}
             onReadyStateChange={onReadyStateChange}
             queryConfig={route}
-            relayContext={relayContext}
+            relayEnvironment={relayEnvironment}
             render={render}
         />
     );
@@ -44,11 +44,11 @@ function IsomorphicRootContainer({
 }
 
 IsomorphicRootContainer.defaultProps = {
-    relayContext: Relay.Store,
+    relayEnvironment: Relay.Store,
 };
 IsomorphicRootContainer.propTypes = {
     ...Relay.RootContainer.propTypes,
-    relayContext: Relay.PropTypes.Context,
+    relayEnvironment: Relay.PropTypes.Context,
 };
 IsomorphicRootContainer.childContextTypes = Relay.RootContainer.childContextTypes;
 

--- a/src/prepareData.js
+++ b/src/prepareData.js
@@ -1,11 +1,11 @@
 import Relay from 'react-relay';
-import RelayContext from 'react-relay/lib/RelayContext';
+import RelayEnvironment from 'react-relay/lib/RelayEnvironment';
 import toGraphQL from 'react-relay/lib/toGraphQL';
 
 export default function prepareData({Component, route}) {
     return new Promise((resolve, reject) => {
-        const relayContext = new RelayContext();
-        const storeData = relayContext.getStoreData();
+        const relayEnvironment = new RelayEnvironment();
+        const storeData = relayEnvironment.getStoreData();
 
         storeData.getChangeEmitter().injectBatchingStrategy(() => {});
 
@@ -19,7 +19,7 @@ export default function prepareData({Component, route}) {
 
         const querySet = Relay.getQueries(Component, route);
 
-        relayContext.forceFetch(querySet, onReadyStateChange);
+        relayEnvironment.forceFetch(querySet, onReadyStateChange);
 
         function onReadyStateChange({aborted, done, error, stale}) {
             if (error) {
@@ -29,7 +29,7 @@ export default function prepareData({Component, route}) {
             } else if (done && !stale) {
                 const props = {
                     Component,
-                    relayContext,
+                    relayEnvironment,
                     route,
                 };
                 resolve({data, props});


### PR DESCRIPTION
I've updated some packages, in particular Relay and React/ReactDOM peers.

**Relay update breaks the library**, I've tested this on my project but (a) I'm not really an expert with Relay and (b) surely my project isn't a torough test for the library.

Anyway, in the new version of Relay (0.8.0), `RelayContext` is replaced by `RelayEnviroment` but apparently they are not exactly equivalent.

Indeed this error is raised

```
Invariant Violation: RelayNetworkLayer: Use `injectNetworkLayer` to configure a network layer.
```

From [this line](https://github.com/denvned/isomorphic-relay/pull/32/files#diff-150062904076cfdfef7bdc3381ec3540R22).
