### PR TITLE
Add mutation to the example (uses global Store as environment in client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,15 @@ app.get('/', (req, res, next) => {
 });
 ```
 
-On page load **in the browser**, create an instance of `Relay.Environment`, inject an Relay network
-layer to it. Then inject the prepared data using `IsomorphicRelay.injectPreparedData`, prepare
+On page load **in the browser**, 
+inject the prepared data using `IsomorphicRelay.injectPreparedData`, prepare
 initial render using `IsomorphicRelay.prepareInitialRender`, and render React using
 `IsomorphicRelay.Renderer` in place of `Relay.Renderer` (pass `props` returned by
 `IsomorphicRelay.prepareInitialRender`):
 ```javascript
 import IsomorphicRelay from 'isomorphic-relay';
 
-const environment = new Relay.Environment();
-
-environment.injectNetworkLayer(new Relay.DefaultNetworkLayer('/graphql'));
+const environment = Relay.Store;
 
 const data = JSON.parse(document.getElementById('preloadedData').textContent);
 

--- a/examples/star-wars/data/schema.json
+++ b/examples/star-wars/data/schema.json
@@ -110,6 +110,18 @@
               "deprecationReason": null
             },
             {
+              "name": "factionId",
+              "description": "id of faction in db",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": "The name of the faction.",
               "args": [],
@@ -545,12 +557,12 @@
           "description": null,
           "fields": [
             {
-              "name": "ship",
+              "name": "newShipEdge",
               "description": null,
               "args": [],
               "type": {
                 "kind": "OBJECT",
-                "name": "Ship",
+                "name": "ShipEdge",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/examples/star-wars/src/client.js
+++ b/examples/star-wars/src/client.js
@@ -4,9 +4,7 @@ import Relay from 'react-relay';
 import IsomorphicRelay from 'isomorphic-relay';
 import rootContainerProps from './rootContainerProps';
 
-const environment = new Relay.Environment();
-
-environment.injectNetworkLayer(new Relay.DefaultNetworkLayer('/graphql'));
+const environment = Relay.Store;
 
 const data = JSON.parse(document.getElementById('preloadedData').textContent);
 

--- a/examples/star-wars/src/components/StarWarsApp.js
+++ b/examples/star-wars/src/components/StarWarsApp.js
@@ -13,8 +13,21 @@
 import React from 'react';
 import Relay from 'react-relay';
 import StarWarsShip from './StarWarsShip';
+import AddShipMutation from '../mutation/AddShipMutation';
 
 class StarWarsApp extends React.Component {
+  constructor() {
+    super();
+    this.state = {factionId: 1, shipName: ''};
+  }
+
+  handleAddShip() {
+    const name = this.state.shipName;
+    const faction = this.props.factions[this.state.factionId];
+    Relay.Store.commitUpdate(new AddShipMutation({name, faction}));
+    this.setState({shipName: ''});
+  }
+
   render() {
     var {factions} = this.props;
     return (
@@ -29,6 +42,32 @@ class StarWarsApp extends React.Component {
             </ol>
           </li>
         ))}
+          <li>
+            <h1>Introduce Ship</h1>
+            <ol>
+              <li>
+                Name:
+                <input
+                  type="text"
+                  value={this.state.shipName}
+                  onChange={e => this.setState({shipName: e.target.value})}
+                />
+              </li>
+              <li>
+                Faction:
+                <select
+                  value={this.state.factionId}
+                  onChange={e => this.setState({factionId: e.target.value})}
+                >
+                  <option value="0">Galactic Empire</option>
+                  <option value="1">Alliance to Restore the Republic</option>
+                </select>
+              </li>
+              <li>
+                <button onClick={this.handleAddShip.bind(this)}>Add Ship</button>
+              </li>
+            </ol>
+          </li>
       </ol>
     );
   }
@@ -39,6 +78,7 @@ export default Relay.createContainer(StarWarsApp, {
     factions: () => Relay.QL`
       fragment on Faction @relay(plural: true) {
         id,
+        factionId,
         name,
         ships(first: 10) {
           edges {
@@ -48,6 +88,7 @@ export default Relay.createContainer(StarWarsApp, {
             }
           }
         }
+        ${AddShipMutation.getFragment('faction')},
       }
     `,
   },

--- a/examples/star-wars/src/data/database.js
+++ b/examples/star-wars/src/data/database.js
@@ -104,6 +104,10 @@ export function getShip(id) {
   return data.Ship[id];
 }
 
+export function getShips(id) {
+  return data.Faction[id].ships.map(shipId => data.Ship[shipId]);
+}
+
 export function getFaction(id) {
   return data.Faction[id];
 }

--- a/examples/star-wars/src/mutation/AddShipMutation.js
+++ b/examples/star-wars/src/mutation/AddShipMutation.js
@@ -1,0 +1,72 @@
+// From: https://github.com/facebook/relay/blob/master/examples/star-wars/js/mutation/AddShipMutation.js
+
+import Relay from 'react-relay';
+
+export default class AddShipMutation extends Relay.Mutation {
+
+  static fragments = {
+    faction: () => Relay.QL`
+      fragment on Faction {
+        id,
+        factionId
+      }
+    `,
+  };
+
+  getMutation() {
+    return Relay.QL`mutation { introduceShip }`;
+  }
+
+  getVariables() {
+    return {
+      shipName: this.props.name,
+      factionId: this.props.faction.factionId,
+    };
+  }
+
+  getFatQuery() {
+    return Relay.QL`
+      fragment on IntroduceShipPayload @relay(pattern: true) {
+        faction {
+          name
+          ships {
+            edges {
+              node {
+                name
+              }
+            }
+          }
+        }
+        newShipEdge
+      }
+    `;
+  }
+
+  getConfigs() {
+    return [{
+      type: 'RANGE_ADD',
+      parentName: 'faction',
+      parentID: this.props.faction.id,
+      connectionName: 'ships',
+      edgeName: 'newShipEdge',
+      rangeBehaviors: {
+        '': 'append',
+        'orderby(oldest)': 'prepend',
+      },
+    }];
+  }
+
+  getOptimisticResponse() {
+    return {
+      newShipEdge: {
+        node: {
+          name: this.props.name,
+        },
+      },
+      faction: {
+        id: this.props.faction.id,
+      },
+    };
+  }
+
+}


### PR DESCRIPTION
This PR adds the mutation `AddShipMutation` to the example, adapted from [the official Relay repo](https://github.com/facebook/relay/blob/master/examples/star-wars/js/mutation/AddShipMutation.js).

For mutations to work, I had to change the client-side configuration a bit. You'll see in src/client that I directly use as Relay environment the global default Relay.Store. Note that this environment is the same as the one used to apply mutations, e.g. in src/components/StarWarsApp.js: `handleAppShip()`. I have updated the README file accordingly.
