### PR TITLE
Bind _retry to the component instance

### DIFF
--- a/src/IsomorphicRenderer.js
+++ b/src/IsomorphicRenderer.js
@@ -17,8 +17,8 @@ export default class IsomorphicRenderer extends React.Component {
     this.state = {
       active: !!props.initialReadyState,
       readyState: props.initialReadyState || INACTIVE_READY_STATE,
-      retry: this._retry.bind(this),
     };
+    this._retry = this._retry.bind(this)
   }
 
   componentDidMount() {
@@ -109,7 +109,7 @@ export default class IsomorphicRenderer extends React.Component {
         queryConfig={this.props.queryConfig}
         readyState={readyState}
         render={this.props.render}
-        retry={this.state.retry}
+        retry={this._retry}
       />
     );
   }


### PR DESCRIPTION
Since `_retry` is never overwritten or changed it doesn't need to be stored in state. By just binding it to the instance in the `constructor` you avoid any cost associated with state updates.
