### PR TITLE
Allow for one off query overrides

### DIFF
--- a/src/prepareData.js
+++ b/src/prepareData.js
@@ -1,7 +1,7 @@
 import Relay from 'react-relay';
 import toGraphQL from 'react-relay/lib/toGraphQL';
 
-export default function prepareData({ Container, queryConfig }, networkLayer) {
+export default function prepareData({ Container, queryConfig }, networkLayer, overrides) {
   return new Promise((resolve, reject) => {
     const environment = new Relay.Environment();
 
@@ -18,7 +18,7 @@ export default function prepareData({ Container, queryConfig }, networkLayer) {
           });
         }
 
-        return networkLayer.sendQueries(requests);
+        return networkLayer.sendQueries(requests, overrides);
       },
     });
 


### PR DESCRIPTION
Hello, my name is Todd and I'm a huge fan of your codebase!
An issue I'm encountering though is due to how the current solution for serverside rendering requires modifying the network global via injectNetworkLayer, so I'm pitching this change to the relay team: https://github.com/facebook/relay/pull/1290

Instead of changing our serverside rendering context via injectNetworkLayer and routing queries through a FIFO system, I'd like to pass an overrides object as an additional argument, where fields are provided to modify my request as needed in the network layer. Please weigh in as you feel in both this thread and that one, as I am still getting comfortable with Relay. If this works for everyone though, this should be all that's needed to make server side rendering much cleaner.
