### PR TITLE
allowing any version of patch / minor for react-relay 8 or 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.8 || ^15.0.1",
-    "react-relay": "0.8.0 || 0.9.0"
+    "react-relay": "^0.8.0 || ^0.9.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     "url": "git+https://github.com/denvned/isomorphic-relay.git"
   },
   "scripts": {
+    "postinstall": "postinstall-build lib \"npm run build\"",
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1"
+    "babel-runtime": "^6.6.1",
+    "postinstall-build": "^0.2.1"
   },
   "peerDependencies": {
     "react": "^0.14.8 || ^15.0.1",

--- a/package.json
+++ b/package.json
@@ -26,13 +26,11 @@
     "url": "git+https://github.com/denvned/isomorphic-relay.git"
   },
   "scripts": {
-    "postinstall": "postinstall-build lib \"npm run build\"",
     "build": "babel src --out-dir lib",
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "babel-runtime": "^6.6.1",
-    "postinstall-build": "^0.2.1"
+    "babel-runtime": "^6.6.1"
   },
   "peerDependencies": {
     "react": "^0.14.8 || ^15.0.1",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-relay-plugin": "0.8.0",
+    "babel-relay-plugin": "^0.9.0",
     "react": "^15.0.1",
-    "react-relay": "0.9.0"
+    "react-relay": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "isomorphic-relay",
+  "name": "isomorphic-relay-correct-deps",
   "version": "0.7.0",
   "description": "Adds server side rendering support to React Relay",
   "author": "Denis Nedelyaev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-relay-correct-deps",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Adds server side rendering support to React Relay",
   "author": "Denis Nedelyaev",
   "homepage": "https://github.com/denvned/isomorphic-relay",


### PR DESCRIPTION
Fixes a peerdep error / warning when installing with latest version of react-relay, which is currently at `0.9.2`.
