### PR TITLE
relaxed semver for devdeps so peerdep restrictions dont fail npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-relay-plugin": "0.8.0",
+    "babel-relay-plugin": "^0.9.0",
     "react": "^15.0.1",
-    "react-relay": "0.9.0"
+    "react-relay": "^0.9.0"
   }
 }


### PR DESCRIPTION
I get the following error if I run `npm install` inside this package without this change:

``` txt
npm ERR! peerinvalid The package babel-relay-plugin@0.8.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-relay@0.9.0 wants babel-relay-plugin@0.9.0
```
