### PR TITLE
Update to support react-relay@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.8 || ^15.0.1",
-    "react-relay": "0.9.3 - 0.10.0"
+    "react-relay": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
@@ -45,6 +45,6 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-relay-plugin": "0.9.3",
     "react": "^15.0.1",
-    "react-relay": "0.9.3"
+    "react-relay": "^1.0.0"
   }
 }

--- a/src/IsomorphicRenderer.js
+++ b/src/IsomorphicRenderer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Relay from 'react-relay';
+import Relay from 'react-relay/classic';
 
 const INACTIVE_READY_STATE = {
   aborted: false,

--- a/src/prepareData.js
+++ b/src/prepareData.js
@@ -1,4 +1,4 @@
-import Relay from 'react-relay';
+import Relay from 'react-relay/classic';
 import toGraphQL from 'react-relay/lib/toGraphQL';
 
 export default function prepareData(

--- a/src/prepareInitialRender.js
+++ b/src/prepareInitialRender.js
@@ -1,4 +1,4 @@
-import Relay from 'react-relay';
+import Relay from 'react-relay/classic';
 
 export default function prepareInitialRender(props) {
   return new Promise(resolve => {


### PR DESCRIPTION
Update requires to use `react-relay/classic` to allow use with Relay 1.0.0 apps that are in the classic -> modern migration process. I don't think this package will be required any more for fully modernized isomorphic relay apps.

Should be published as a major breaking change.