### PR TITLE
Use prop-types package for PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-runtime": "^6.6.1"
   },
   "peerDependencies": {
+    "prop-types": "^15.0.0",
     "react": "^0.14.8 || ^15.0.1",
     "react-relay": "0.9.3 - 0.10.0"
   },
@@ -44,6 +45,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "babel-relay-plugin": "0.9.3",
+    "prop-types": "^15.5.10",
     "react": "^15.0.1",
     "react-relay": "0.9.3"
   }

--- a/src/IsomorphicRenderer.js
+++ b/src/IsomorphicRenderer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Relay from 'react-relay';
 
 const INACTIVE_READY_STATE = {
@@ -122,19 +123,19 @@ export default class IsomorphicRenderer extends React.Component {
 
 IsomorphicRenderer.propTypes = {
   Container: Relay.PropTypes.Container,
-  forceFetch: React.PropTypes.bool,
-  initialReadyState: React.PropTypes.shape({
-    aborted: React.PropTypes.bool.isRequired,
-    done: React.PropTypes.bool.isRequired,
-    error: React.PropTypes.any,
-    ready: React.PropTypes.bool.isRequired,
-    stale: React.PropTypes.bool.isRequired,
+  forceFetch: PropTypes.bool,
+  initialReadyState: PropTypes.shape({
+    aborted: PropTypes.bool.isRequired,
+    done: PropTypes.bool.isRequired,
+    error: PropTypes.any,
+    ready: PropTypes.bool.isRequired,
+    stale: PropTypes.bool.isRequired,
   }),
-  onReadyStateChange: React.PropTypes.func,
+  onReadyStateChange: PropTypes.func,
   queryConfig: Relay.PropTypes.QueryConfig.isRequired,
   environment: Relay.PropTypes.Environment,
-  render: React.PropTypes.func,
-  shouldFetch: React.PropTypes.bool,
+  render: PropTypes.func,
+  shouldFetch: PropTypes.bool,
 };
 
 IsomorphicRenderer.defaultProps = {


### PR DESCRIPTION
React has deprecated accessing the PropTypes from the React object itself and recommends using the prop-types module instead.